### PR TITLE
Add quantity selector to product details before adding to cart

### DIFF
--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -34,7 +34,11 @@
 
 
             <!-- Lista produktów -->
-            <ListView x:Name="ProductList" Grid.Row="1" Margin="5" ItemsSource="{Binding Products}">
+            <ListView x:Name="ProductList"
+          Grid.Row="1"
+          Margin="5"
+          ItemsSource="{Binding Products}"
+          MouseDoubleClick="ProductList_MouseDoubleClick">
                 <ListView.View>
                     <GridView>
                         <GridViewColumn Header="{Binding NameHeader}" Width="200">
@@ -49,7 +53,6 @@
                         </GridViewColumn>
 
                         <GridViewColumn Header="Opis" Width="300" DisplayMemberBinding="{Binding Description}"/>
-
                         <GridViewColumn Header="{Binding PriceHeader}" Width="100">
                             <GridViewColumn.HeaderContainerStyle>
                                 <Style TargetType="GridViewColumnHeader">
@@ -62,18 +65,10 @@
                         </GridViewColumn>
 
                         <GridViewColumn Header="Kategoria" Width="150" DisplayMemberBinding="{Binding CategoryName}"/>
-
-                        <GridViewColumn Header="Koszyk" Width="120">
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <Button Content="Dodaj do koszyka" Click="AddToCart_Click"/>
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-
                     </GridView>
                 </ListView.View>
             </ListView>
+
         </Grid>
 
     </DockPanel>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -82,6 +82,15 @@ namespace SklepInternetowyWPF.Views
 
             viewModel.LoadProducts();
         }
+        private void ProductList_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (ProductList.SelectedItem is Product selected)
+            {
+                var detailsWindow = new ProductDetailsWindow(selected, cartViewModel);
+                detailsWindow.ShowDialog();
+            }
+        }
+
         private void Cart_Click(object sender, RoutedEventArgs e)
         {
             var window = new CartWindow(cartViewModel);

--- a/Views/ProductDetailsWindow.xaml
+++ b/Views/ProductDetailsWindow.xaml
@@ -2,16 +2,32 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Szczegóły produktu" Height="300" Width="400">
-    <StackPanel Margin="20">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
         <TextBlock Text="Nazwa:" FontWeight="Bold"/>
-        <TextBlock Text="{Binding Name}" Margin="0,0,0,10"/>
+        <TextBlock x:Name="NameText" Grid.Row="0" Margin="60,0,0,0"/>
 
-        <TextBlock Text="Opis:" FontWeight="Bold"/>
-        <TextBlock Text="{Binding Description}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+        <TextBlock Text="Opis:" FontWeight="Bold" Grid.Row="1"/>
+        <TextBlock x:Name="DescText" Grid.Row="1" Margin="60,0,0,0"/>
 
-        <TextBlock Text="Cena:" FontWeight="Bold"/>
-        <TextBlock Text="{Binding Price}" Margin="0,0,0,10"/>
+        <TextBlock Text="Cena:" FontWeight="Bold" Grid.Row="2"/>
+        <TextBlock x:Name="PriceText" Grid.Row="2" Margin="60,0,0,0"/>
 
-        <Button Content="Dodaj do koszyka" Width="150" HorizontalAlignment="Center"/>
-    </StackPanel>
+        <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="0,10,0,0">
+            <TextBlock Text="Ilość:" FontWeight="Bold" VerticalAlignment="Center"/>
+            <TextBox x:Name="QuantityBox" Width="50" Margin="10,0,0,0" Text="1"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Dodaj do koszyka" Click="AddToCart_Click" Margin="5"/>
+            <Button Content="Zamknij" Click="Close_Click" Margin="5"/>
+        </StackPanel>
+    </Grid>
 </Window>

--- a/Views/ProductDetailsWindow.xaml.cs
+++ b/Views/ProductDetailsWindow.xaml.cs
@@ -1,27 +1,44 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+﻿using System.Windows;
+using SklepInternetowyWPF.Models;
+using SklepInternetowyWPF.ViewModels;
 
 namespace SklepInternetowyWPF.Views
 {
-    /// <summary>
-    /// Logika interakcji dla klasy ProductDetailsWindow.xaml
-    /// </summary>
     public partial class ProductDetailsWindow : Window
     {
-        public ProductDetailsWindow()
+        private readonly Product product;
+        private readonly CartViewModel cart;
+
+        public ProductDetailsWindow(Product product, CartViewModel cart)
         {
             InitializeComponent();
+            this.product = product;
+            this.cart = cart;
+
+            NameText.Text = product.Name;
+            DescText.Text = product.Description;
+            PriceText.Text = $"{product.Price:C}";
+        }
+
+        private void AddToCart_Click(object sender, RoutedEventArgs e)
+        {
+            if (!int.TryParse(QuantityBox.Text, out int quantity) || quantity <= 0)
+            {
+                MessageBox.Show("Podaj prawidłową ilość.");
+                return;
+            }
+
+            for (int i = 0; i < quantity; i++)
+                cart.AddToCart(product);
+
+            MessageBox.Show($"Dodano {quantity} szt. do koszyka.");
+            Close();
+        }
+
+
+        private void Close_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Double-clicking a product in the list now opens a detailed view for additional product information.
  - The product details view lets users specify a quantity and add the product to their cart with confirmation messages.

- **Refactor**
  - Streamlined the product list by removing direct add-to-cart options.
  - Enhanced the product details layout for a clearer, more organized display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->