### PR TITLE
Add print support for order history and product statistics

### DIFF
--- a/Views/EditProductWindow.xaml.cs
+++ b/Views/EditProductWindow.xaml.cs
@@ -47,7 +47,7 @@ namespace SklepInternetowyWPF.Views
                         existing.CategoryId = Product.CategoryId;
                         existing.Stock = Product.Stock;
                         existing.StockMax = Product.StockMax;
-                        existing.ImagePath = Product.ImagePath; // <- kluczowe
+                        existing.ImagePath = Product.ImagePath;
                         db.SaveChanges();
                     }
                 }

--- a/Views/OrderHistoryWindow.xaml
+++ b/Views/OrderHistoryWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:converters="clr-namespace:SklepInternetowyWPF.Converters"
-        Title="Historia zamówień" Height="450" Width="600"
+        Title="Historia zamówień" Height="500" Width="650"
         Loaded="Window_Loaded"
         Background="#EDF4FF">
 
@@ -10,49 +10,68 @@
         <Storyboard x:Key="FadeInStoryboard">
             <DoubleAnimation Storyboard.TargetProperty="Opacity" From="0" To="1" Duration="0:0:0.5"/>
         </Storyboard>
+        <converters:ZeroToVisibilityConverter x:Key="ZeroToVisibilityConverter"/>
     </Window.Resources>
-    
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="10">
-            <TextBlock Text="Twoje zamówienia:"
-                       FontSize="18"
-                       FontWeight="Bold"
-                       Foreground="#1B1C2E"
-                       Margin="0,0,0,10"/>
 
-            <ItemsControl ItemsSource="{Binding Orders}">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Border BorderBrush="#90C4E4" BorderThickness="1" Margin="0,0,0,10" Padding="10" Background="White">
-                            <StackPanel>
-                                <TextBlock FontWeight="Bold"
-                                           Foreground="#1B1C2E"
-                                           Text="{Binding Date, StringFormat='Zamówienie z dnia: {0:yyyy-MM-dd HH:mm}'}"/>
-                                <ItemsControl ItemsSource="{Binding Items}">
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate>
-                                            <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="{Binding Product.Name}" Width="200" Foreground="#1B1C2E"/>
-                                                <TextBlock Text="{Binding Quantity}" Width="50" Foreground="#1B1C2E"/>
-                                                <TextBlock Text="{Binding Total, StringFormat='{}{0:C}'}" Foreground="#1B1C2E"/>
-                                            </StackPanel>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
-                                <TextBlock FontWeight="Bold"
-                                           Foreground="#1B1C2E"
-                                           Text="{Binding Total, StringFormat='Łącznie: {0:C}'}"
-                                           Margin="0,5,0,0"/>
-                            </StackPanel>
-                        </Border>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
 
-            <TextBlock Text="Brak zamówień."
-                       FontStyle="Italic"
-                       Foreground="Gray"
-                       Visibility="{Binding Orders.Count, Converter={StaticResource ZeroToVisibilityConverter}}"/>
-        </StackPanel>
-    </ScrollViewer>
+        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
+            <StackPanel x:Name="OrderContent" Margin="0,0,10,0">
+                <TextBlock Text="Twoje zamówienia:"
+                           FontSize="18"
+                           FontWeight="Bold"
+                           Foreground="#1B1C2E"
+                           Margin="0,0,0,10"/>
+
+                <ItemsControl ItemsSource="{Binding Orders}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border BorderBrush="#90C4E4" BorderThickness="1" Margin="0,0,0,10" Padding="10" Background="White">
+                                <StackPanel>
+                                    <TextBlock FontWeight="Bold"
+                                               Foreground="#1B1C2E"
+                                               Text="{Binding Date, StringFormat='Zamówienie z dnia: {0:yyyy-MM-dd HH:mm}'}"/>
+                                    <ItemsControl ItemsSource="{Binding Items}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <StackPanel Orientation="Horizontal">
+                                                    <TextBlock Text="{Binding Product.Name}" Width="200" Foreground="#1B1C2E"/>
+                                                    <TextBlock Text="{Binding Quantity}" Width="50" Foreground="#1B1C2E"/>
+                                                    <TextBlock Text="{Binding Total, StringFormat='{}{0:C}'}" Foreground="#1B1C2E"/>
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                    <TextBlock FontWeight="Bold"
+                                               Foreground="#1B1C2E"
+                                               Text="{Binding Total, StringFormat='Łącznie: {0:C}'}"
+                                               Margin="0,5,0,0"/>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <TextBlock Text="Brak zamówień."
+                           FontStyle="Italic"
+                           Foreground="Gray"
+                           Visibility="{Binding Orders.Count, Converter={StaticResource ZeroToVisibilityConverter}}"/>
+            </StackPanel>
+        </ScrollViewer>
+
+        <Button Content="Drukuj"
+                Grid.Row="1"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
+                Margin="0,10,0,0"
+                Width="90"
+                Height="30"
+                Click="Print_Click"
+                Background="#90C4E4"
+                Foreground="#1B1C2E"/>
+    </Grid>
 </Window>

--- a/Views/OrderHistoryWindow.xaml.cs
+++ b/Views/OrderHistoryWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media.Animation;
 using SklepInternetowyWPF.ViewModels;
 
@@ -18,6 +19,13 @@ namespace SklepInternetowyWPF.Views
             var storyboard = (Storyboard)this.Resources["FadeInStoryboard"];
             storyboard.Begin(this);
         }
-
+        private void Print_Click(object sender, RoutedEventArgs e)
+        {
+            PrintDialog printDialog = new PrintDialog();
+            if (printDialog.ShowDialog() == true)
+            {
+                printDialog.PrintVisual(OrderContent, "Historia zamówień");
+            }
+        }
     }
 }

--- a/Views/StatisticsWindow.xaml
+++ b/Views/StatisticsWindow.xaml
@@ -15,6 +15,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <TextBlock Text="Najczęściej kupowane produkty"
@@ -40,5 +41,12 @@
                 </GridView>
             </ListView.View>
         </ListView>
+
+        <Button Content="Drukuj"
+                Grid.Row="2"
+                Width="80" Height="30" Margin="0,10,0,0"
+                HorizontalAlignment="Right"
+                Click="Print_Click"
+                Background="#90C4E4" Foreground="#1B1C2E"/>
     </Grid>
 </Window>

--- a/Views/StatisticsWindow.xaml.cs
+++ b/Views/StatisticsWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media.Animation;
 using SklepInternetowyWPF.ViewModels;
 
@@ -16,6 +17,13 @@ namespace SklepInternetowyWPF.Views
             var storyboard = (Storyboard)this.Resources["FadeInStoryboard"];
             storyboard.Begin(this);
         }
-
+        private void Print_Click(object sender, RoutedEventArgs e)
+        {
+            PrintDialog dialog = new PrintDialog();
+            if (dialog.ShowDialog() == true)
+            {
+                dialog.PrintVisual(StatsListView, "Statystyki sprzedaży");
+            }
+        }
     }
 }


### PR DESCRIPTION
- Added Print button and logic to OrderHistoryWindow and StatisticsWindow
- Implemented printing for ListView contents via PrintDialog
- Extended OrderHistoryViewModel for detailed order info
- Ensured consistent styling for print-friendly layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgraded the Order History window with a larger, more organized layout and a new Print button for printing order details.
  - Enhanced the Statistics view by adding a Print button, allowing users to easily print sales statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->