### PR TITLE
Add PDF export for cart, order history and statistics

### DIFF
--- a/SklepInternetowyWPF.csproj
+++ b/SklepInternetowyWPF.csproj
@@ -114,6 +114,12 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="PdfSharp, Version=1.50.5147.0, Culture=neutral, PublicKeyToken=f94615aa0424f9eb, processorArchitecture=MSIL">
+      <HintPath>packages\PDFsharp.1.50.5147\lib\net20\PdfSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="PdfSharp.Charting, Version=1.50.5147.0, Culture=neutral, PublicKeyToken=f94615aa0424f9eb, processorArchitecture=MSIL">
+      <HintPath>packages\PDFsharp.1.50.5147\lib\net20\PdfSharp.Charting.dll</HintPath>
+    </Reference>
     <Reference Include="SQLitePCLRaw.batteries_v2, Version=2.0.7.1395, Culture=neutral, PublicKeyToken=8226ea5df37bcae9, processorArchitecture=MSIL">
       <HintPath>packages\SQLitePCLRaw.bundle_e_sqlite3.2.0.7\lib\net461\SQLitePCLRaw.batteries_v2.dll</HintPath>
     </Reference>
@@ -153,6 +159,7 @@
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Diagnostics.DiagnosticSource.4.7.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
     </Reference>
@@ -200,6 +207,7 @@
     <Compile Include="Models\Product.cs" />
     <Compile Include="Models\ProductStatistics.cs" />
     <Compile Include="Models\User.cs" />
+    <Compile Include="Utils\PdfExporter.cs" />
     <Compile Include="Validators\PositiveDecimalValidationRule.cs" />
     <Compile Include="Validators\PositiveIntegerValidationRule.cs" />
     <Compile Include="Validators\RequiredFieldValidationRule.cs" />

--- a/Utils/PdfExporter.cs
+++ b/Utils/PdfExporter.cs
@@ -1,0 +1,104 @@
+﻿using PdfSharp.Drawing;
+using PdfSharp.Pdf;
+using SklepInternetowyWPF.Models;
+using SklepInternetowyWPF.ViewModels;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows.Media;
+
+namespace SklepInternetowyWPF.Utils
+{
+    public static class PdfExporter
+    {
+        public static void ExportCartToPdf(CartViewModel cart)
+        {
+            var doc = new PdfDocument();
+            doc.Info.Title = "Koszyk";
+
+            var page = doc.AddPage();
+            var gfx = XGraphics.FromPdfPage(page);
+            var font = new XFont("Verdana", 12);
+            double y = 40;
+            gfx.DrawString("Koszyk", new XFont("Verdana", 16, XFontStyle.Bold), XBrushes.Black, 20, y);
+            y += 30;
+
+            foreach (var item in cart.CartItems)
+            {
+                string line = $"{item.Product.Name} x {item.Quantity} - {item.Total:C}";
+                gfx.DrawString(line, font, XBrushes.Black, 20, y);
+                y += 20;
+            }
+
+            y += 10;
+            gfx.DrawString($"Łącznie: {cart.Total:C}", font, XBrushes.Black, 20, y);
+
+            SavePdf(doc, "Koszyk");
+        }
+
+        public static void ExportOrderHistory(OrderViewModel orderVM)
+        {
+            var doc = new PdfDocument();
+            doc.Info.Title = "Historia zamówień";
+
+            var page = doc.AddPage();
+            var gfx = XGraphics.FromPdfPage(page);
+            var font = new XFont("Verdana", 12);
+            double y = 40;
+            gfx.DrawString("Historia zamówień", new XFont("Verdana", 16, XFontStyle.Bold), XBrushes.Black, 20, y);
+            y += 30;
+
+            foreach (var order in orderVM.Orders)
+            {
+                gfx.DrawString($"Zamówienie: {order.Date:yyyy-MM-dd HH:mm}", font, XBrushes.Black, 20, y);
+                y += 20;
+
+                foreach (var item in order.Items)
+                {
+                    gfx.DrawString($"- {item.Product.Name} x {item.Quantity} = {item.Total:C}", font, XBrushes.Black, 30, y);
+                    y += 20;
+                }
+
+                gfx.DrawString($"Łącznie: {order.Total:C}", font, XBrushes.Black, 20, y);
+                y += 30;
+            }
+
+            SavePdf(doc, "HistoriaZamowien");
+        }
+
+        public static void ExportStatistics(ProductViewModel viewModel)
+        {
+            var top = viewModel.GetTopSellingProducts();
+
+            var doc = new PdfDocument();
+            doc.Info.Title = "Statystyki";
+
+            var page = doc.AddPage();
+            var gfx = XGraphics.FromPdfPage(page);
+            var font = new XFont("Verdana", 12);
+            double y = 40;
+            gfx.DrawString("Najczęściej kupowane produkty", new XFont("Verdana", 16, XFontStyle.Bold), XBrushes.Black, 20, y);
+            y += 30;
+
+            foreach (var item in top)
+            {
+                string line = $"{item.ProductName} - {item.TotalQuantitySold} szt.";
+                gfx.DrawString(line, font, XBrushes.Black, 20, y);
+                y += 20;
+            }
+
+            SavePdf(doc, "StatystykiSprzedazy");
+        }
+
+        private static void SavePdf(PdfDocument doc, string filenamePrefix)
+        {
+            string folder = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Exports");
+            Directory.CreateDirectory(folder);
+            string filePath = Path.Combine(folder, $"{filenamePrefix}_{DateTime.Now:yyyyMMdd_HHmmss}.pdf");
+
+            doc.Save(filePath);
+            Process.Start("explorer.exe", filePath);
+        }
+    }
+}

--- a/Views/CartWindow.xaml
+++ b/Views/CartWindow.xaml
@@ -43,7 +43,13 @@
                         Click="PlaceOrder_Click"
                         Background="#90C4E4"
                         Foreground="#1B1C2E"/>
-
+                <Button Content="Eksportuj do PDF"
+                        Width="120"
+                        Height="30"
+                        Margin="5"
+                        Click="ExportToPdf_Click"
+                        Background="#9AD4D6"
+                        Foreground="#1B1C2E"/>
                 <Button Content="Wyczyść"
                         Width="80"
                         Height="30"

--- a/Views/CartWindow.xaml.cs
+++ b/Views/CartWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Linq;
 using System.Windows.Media.Animation;
+using SklepInternetowyWPF.Utils;
 
 namespace SklepInternetowyWPF.Views
 {
@@ -39,6 +40,10 @@ namespace SklepInternetowyWPF.Views
         private void Close_Click(object sender, RoutedEventArgs e)
         {
             Close();
+        }
+        private void ExportToPdf_Click(object sender, RoutedEventArgs e)
+        {
+            PdfExporter.ExportCartToPdf(cartViewModel);
         }
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {

--- a/Views/OrderHistoryWindow.xaml
+++ b/Views/OrderHistoryWindow.xaml
@@ -63,15 +63,22 @@
             </StackPanel>
         </ScrollViewer>
 
-        <Button Content="Drukuj"
-                Grid.Row="1"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Bottom"
-                Margin="0,10,0,0"
-                Width="90"
-                Height="30"
-                Click="Print_Click"
-                Background="#90C4E4"
-                Foreground="#1B1C2E"/>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Eksportuj do PDF"
+            Width="120"
+            Height="30"
+            Margin="0,0,10,0"
+            Click="ExportToPdf_Click"
+            Background="#9AD4D6"
+            Foreground="#1B1C2E"/>
+
+            <Button Content="Drukuj"
+            Width="90"
+            Height="30"
+            Click="Print_Click"
+            Background="#90C4E4"
+            Foreground="#1B1C2E"/>
+        </StackPanel>
+
     </Grid>
 </Window>

--- a/Views/OrderHistoryWindow.xaml.cs
+++ b/Views/OrderHistoryWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Animation;
+using SklepInternetowyWPF.Utils;
 using SklepInternetowyWPF.ViewModels;
 
 namespace SklepInternetowyWPF.Views
@@ -26,6 +27,11 @@ namespace SklepInternetowyWPF.Views
             {
                 printDialog.PrintVisual(OrderContent, "Historia zamówień");
             }
+        }
+        private void ExportToPdf_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is OrderViewModel vm)
+                PdfExporter.ExportOrderHistory(vm);
         }
     }
 }

--- a/Views/StatisticsWindow.xaml
+++ b/Views/StatisticsWindow.xaml
@@ -42,11 +42,21 @@
             </ListView.View>
         </ListView>
 
-        <Button Content="Drukuj"
-                Grid.Row="2"
-                Width="80" Height="30" Margin="0,10,0,0"
-                HorizontalAlignment="Right"
-                Click="Print_Click"
-                Background="#90C4E4" Foreground="#1B1C2E"/>
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Eksportuj do PDF"
+            Width="120"
+            Height="30"
+            Margin="0,0,10,0"
+            Click="ExportToPdf_Click"
+            Background="#9AD4D6"
+            Foreground="#1B1C2E"/>
+            <Button Content="Drukuj"
+            Width="80"
+            Height="30"
+            Click="Print_Click"
+            Background="#90C4E4"
+            Foreground="#1B1C2E"/>
+        </StackPanel>
+
     </Grid>
 </Window>

--- a/Views/StatisticsWindow.xaml.cs
+++ b/Views/StatisticsWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Animation;
+using SklepInternetowyWPF.Utils;
 using SklepInternetowyWPF.ViewModels;
 
 namespace SklepInternetowyWPF.Views
@@ -10,6 +11,7 @@ namespace SklepInternetowyWPF.Views
         public StatisticsWindow(ProductViewModel viewModel)
         {
             InitializeComponent();
+            DataContext = viewModel;
             StatsListView.ItemsSource = viewModel.GetTopSellingProducts();
         }
         private void Window_Loaded(object sender, RoutedEventArgs e)
@@ -25,5 +27,11 @@ namespace SklepInternetowyWPF.Views
                 dialog.PrintVisual(StatsListView, "Statystyki sprzedaży");
             }
         }
+        private void ExportToPdf_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ProductViewModel vm)
+                PdfExporter.ExportStatistics(vm);
+        }
+
     }
 }

--- a/packages.config
+++ b/packages.config
@@ -3,6 +3,7 @@
   <package id="EntityFramework" version="6.4.4" targetFramework="net472" />
   <package id="Microsoft.Data.Sqlite" version="5.0.17" targetFramework="net472" />
   <package id="Microsoft.Data.Sqlite.Core" version="5.0.17" targetFramework="net472" />
+  <package id="PDFsharp" version="1.50.5147" targetFramework="net472" />
   <package id="SQLitePCLRaw.bundle_e_sqlite3" version="2.0.7" targetFramework="net472" />
   <package id="SQLitePCLRaw.core" version="2.0.7" targetFramework="net472" />
   <package id="SQLitePCLRaw.lib.e_sqlite3" version="2.0.7" targetFramework="net472" />


### PR DESCRIPTION
- Implemented PdfExporter utility with support for cart, order history and statistics export using PdfSharp
- Added "Export to PDF" buttons to CartWindow, OrderHistoryWindow and StatisticsWindow
- Fixed missing DataContext binding in StatisticsWindow for correct PDF generation
- PDF files are saved to /Exports and automatically opened after export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced PDF export capability across key areas of the app.
  - Added "Eksportuj do PDF" buttons in shopping cart, order history, and statistics views, enabling users to easily generate PDF documents of their data.
  - Enhanced the overall user interface by providing an additional export option alongside existing print functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->